### PR TITLE
Use bytes crate for no_std support

### DIFF
--- a/crates/matrix-pickle-derive/src/lib.rs
+++ b/crates/matrix-pickle-derive/src/lib.rs
@@ -75,10 +75,10 @@ pub fn derive_encode(input: TokenStream) -> TokenStream {
 
             quote! {
                 impl #impl_generics #matrix_pickle::Encode for #name #ty_generics #where_clause {
-                    fn encode(&self, writer: &mut impl std::io::Write) -> Result<usize, #matrix_pickle::EncodeError> {
+                    fn encode(&self, buf: &mut impl bytes::buf::BufMut) -> Result<usize, #matrix_pickle::EncodeError> {
                         let mut ret = 0;
 
-                        #(ret += self.#idents.encode(writer)?;)*
+                        #(ret += self.#idents.encode(buf)?;)*
 
                         Ok(ret)
                     }
@@ -93,10 +93,10 @@ pub fn derive_encode(input: TokenStream) -> TokenStream {
 
             quote! {
                 impl #impl_generics #matrix_pickle::Encode for #name #ty_generics #where_clause {
-                    fn encode(&self, writer: &mut impl std::io::Write) -> Result<usize, #matrix_pickle::EncodeError> {
+                    fn encode(&self, buf: &mut impl bytes::buf::BufMut) -> Result<usize, #matrix_pickle::EncodeError> {
                         let mut ret = 0;
 
-                        #(ret += self.#i.encode(writer)?;)*
+                        #(ret += self.#i.encode(buf)?;)*
 
                         Ok(ret)
                     }
@@ -109,13 +109,13 @@ pub fn derive_encode(input: TokenStream) -> TokenStream {
 
             quote! {
                 impl #impl_generics #matrix_pickle::Encode for #name #ty_generics #where_clause {
-                    fn encode(&self, writer: &mut impl std::io::Write) -> Result<usize, #matrix_pickle::EncodeError> {
+                    fn encode(&self, buf: &mut impl bytes::buf::BufMut) -> Result<usize, #matrix_pickle::EncodeError> {
                         let mut ret = 0;
 
                         match self {
                             #(#name::#names(v) => {
-                                ret += #numbers.encode(writer)?;
-                                ret += v.encode(writer)?;
+                                ret += #numbers.encode(buf)?;
+                                ret += v.encode(buf)?;
                             }),*
                         }
 
@@ -177,9 +177,9 @@ pub fn derive_decode(input: TokenStream) -> TokenStream {
 
             quote! {
                 impl #impl_generics #matrix_pickle::Decode for #name #ty_generics #where_clause {
-                    fn decode(reader: &mut impl std::io::Read) -> Result<Self, #matrix_pickle::DecodeError> {
+                    fn decode(buf: &mut impl bytes::buf::Buf) -> Result<Self, #matrix_pickle::DecodeError> {
                         Ok(Self {
-                            #(#names: <#field_types>::decode(reader)?),*
+                            #(#names: <#field_types>::decode(buf)?),*
                         })
                     }
                 }
@@ -195,9 +195,9 @@ pub fn derive_decode(input: TokenStream) -> TokenStream {
 
             quote! {
                 impl #impl_generics #matrix_pickle::Decode for #name #ty_generics #where_clause {
-                    fn decode(reader: &mut impl std::io::Read) -> Result<Self, #matrix_pickle::DecodeError> {
+                    fn decode(buf: &mut impl bytes::buf::Buf) -> Result<Self, #matrix_pickle::DecodeError> {
                         Ok(Self (
-                            #(<#field_types>::decode(reader)?),*
+                            #(<#field_types>::decode(buf)?),*
                         ))
                     }
                 }
@@ -209,12 +209,12 @@ pub fn derive_decode(input: TokenStream) -> TokenStream {
 
             quote! {
                 impl #impl_generics #matrix_pickle::Decode for #name #ty_generics #where_clause {
-                    fn decode(reader: &mut impl std::io::Read) -> Result<Self, #matrix_pickle::DecodeError> {
-                        let variant = u8::decode(reader)?;
+                    fn decode(buf: &mut impl bytes::buf::Buf) -> Result<Self, #matrix_pickle::DecodeError> {
+                        let variant = u8::decode(buf)?;
 
                         match variant {
                             #(#numbers => {
-                                let x = Decode::decode(reader)?;
+                                let x = Decode::decode(buf)?;
                                 Ok(Self::#names(x))
                             }),*
 

--- a/crates/matrix-pickle/Cargo.toml
+++ b/crates/matrix-pickle/Cargo.toml
@@ -8,11 +8,13 @@ license = "MIT"
 rust-version = { workspace = true }
 
 [features]
+default = ["std", "derive"]
 derive = ["dep:matrix-pickle-derive"]
-default = ["derive"]
+std = ["bytes/std", "dep:thiserror"]
 
 [dependencies]
-thiserror = "1.0.49"
+bytes = { version = "1.5.0", default-features = false }
+thiserror = { version = "1.0.49", optional = true }
 matrix-pickle-derive = { version = "0.1.1", path = "../matrix-pickle-derive", optional = true}
 
 [dev-dependencies]

--- a/crates/matrix-pickle/README.md
+++ b/crates/matrix-pickle/README.md
@@ -66,7 +66,6 @@ The derive support for structs simply encodes each field of a struct in the orde
 they are defined, for example:
 
 ```rust
-use std::io::Write;
 use matrix_pickle::{Encode, EncodeError};
 
 struct Foo {
@@ -75,13 +74,13 @@ struct Foo {
 }
 
 impl Encode for Foo {
-    fn encode(&self, writer: &mut impl Write) -> Result<usize, EncodeError> {
+    fn encode(&self, buf: &mut impl bytes::buf::BufMut) -> Result<usize, EncodeError> {
         let mut ret = 0;
 
         // Encode the first struct field.
-        ret += self.first.encode(writer)?;
+        ret += self.first.encode(buf)?;
         // Now encode the second struct field.
-        ret += self.second.encode(writer)?;
+        ret += self.second.encode(buf)?;
 
         Ok(ret)
     }
@@ -97,7 +96,6 @@ Only enums with variants that contain a single associated data value are
 supported.
 
 ```rust
-use std::io::Write;
 use matrix_pickle::{Encode, EncodeError};
 
 enum Bar {
@@ -106,21 +104,21 @@ enum Bar {
 }
 
 impl Encode for Bar {
-    fn encode(&self, writer: &mut impl Write) -> Result<usize, EncodeError> {
+    fn encode(&self, buf: &mut impl bytes::buf::BufMut) -> Result<usize, EncodeError> {
         let mut ret = 0;
 
         match self {
             Bar::First(value) => {
                 // This is our first variant, encode a 0u8 first.
-                ret += 0u8.encode(writer)?;
+                ret += 0u8.encode(buf)?;
                 // Now encode the associated value.
-                ret += value.encode(writer)?;
+                ret += value.encode(buf)?;
             },
             Bar::Second(value) => {
                 // This is our second variant, encode a 1u8 first.
-                ret += 1u8.encode(writer)?;
+                ret += 1u8.encode(buf)?;
                 // Now encode the associated value.
-                ret += value.encode(writer)?;
+                ret += value.encode(buf)?;
             },
         }
 

--- a/crates/matrix-pickle/src/decode.rs
+++ b/crates/matrix-pickle/src/decode.rs
@@ -11,57 +11,50 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::io::{Cursor, Read};
-
 use crate::{DecodeError, MAX_ARRAY_LENGTH};
+use alloc::{boxed::Box, vec::Vec};
+use bytes::buf::Buf;
 
 /// A trait for decoding values that were encoded using the `matrix-pickle` binary format.
 pub trait Decode {
     /// Try to read and decode a value from the given reader.
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError>
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError>
     where
         Self: Sized;
 
     /// Try to read and decode a value from the given byte slice.
-    fn decode_from_slice(buffer: &[u8]) -> Result<Self, DecodeError>
+    fn decode_from_slice(buf: &[u8]) -> Result<Self, DecodeError>
     where
         Self: Sized,
     {
-        let mut cursor = Cursor::new(buffer);
-        Self::decode(&mut cursor)
+        let mut b = buf;
+        Self::decode(&mut b)
     }
 }
 
 impl Decode for u8 {
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError> {
-        let mut buffer = [0u8; 1];
-
-        reader.read_exact(&mut buffer)?;
-
-        Ok(buffer[0])
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
+        Ok(buf.get_u8())
     }
 }
 
 impl Decode for bool {
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError> {
-        let value = u8::decode(reader)?;
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
+        let value = u8::decode(buf)?;
 
         Ok(value != 0)
     }
 }
 
 impl Decode for u32 {
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError> {
-        let mut buffer = [0u8; 4];
-        reader.read_exact(&mut buffer)?;
-
-        Ok(u32::from_be_bytes(buffer))
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
+        Ok(buf.get_u32())
     }
 }
 
 impl Decode for usize {
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError> {
-        let size = u32::decode(reader)?;
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
+        let size = u32::decode(buf)?;
 
         size.try_into()
             .map_err(|_| DecodeError::OutsideUsizeRange(size as u64))
@@ -69,38 +62,41 @@ impl Decode for usize {
 }
 
 impl<const N: usize> Decode for [u8; N] {
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError> {
-        let mut buffer = [0u8; N];
-        reader.read_exact(&mut buffer)?;
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
+        let mut dest = [0u8; N];
+        if buf.remaining() < N {
+            return Err(DecodeError::InsufficientData);
+        }
+        buf.copy_to_slice(&mut dest);
 
-        Ok(buffer)
+        Ok(dest)
     }
 }
 
 impl<const N: usize> Decode for Box<[u8; N]> {
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError> {
-        let mut buffer = Box::new([0u8; N]);
-        reader.read_exact(buffer.as_mut_slice())?;
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
+        let mut dest = Box::new([0u8; N]);
+        buf.copy_to_slice(dest.as_mut_slice());
 
-        Ok(buffer)
+        Ok(dest)
     }
 }
 
 impl<T: Decode> Decode for Vec<T> {
-    fn decode(reader: &mut impl Read) -> Result<Self, DecodeError> {
-        let length = usize::decode(reader)?;
+    fn decode(buf: &mut impl Buf) -> Result<Self, DecodeError> {
+        let length = usize::decode(buf)?;
 
         if length > MAX_ARRAY_LENGTH {
             Err(DecodeError::ArrayTooBig(length))
         } else {
-            let mut buffer = Vec::with_capacity(length);
+            let mut dest = Vec::with_capacity(length);
 
             for _ in 0..length {
-                let element = T::decode(reader)?;
-                buffer.push(element);
+                let element = T::decode(buf)?;
+                dest.push(element);
             }
 
-            Ok(buffer)
+            Ok(dest)
         }
     }
 }

--- a/crates/matrix-pickle/src/error.rs
+++ b/crates/matrix-pickle/src/error.rs
@@ -12,41 +12,43 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use thiserror::Error;
-
 /// Error type describing failure modes for libolm pickle decoding.
-#[derive(Debug, Error)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug)]
 pub enum DecodeError {
-    /// There was an error while reading from the source of the libolm, usually
-    /// not enough data was provided.
-    #[error(transparent)]
-    IO(#[from] std::io::Error),
+    /// There was not enough data while reading from the source of the libolm.
+    #[cfg_attr(
+        feature = "std",
+        error("The source does not have enough data to fill the destination")
+    )]
+    InsufficientData,
     /// The encoded usize doesn't fit into the usize of the architecture that is
     /// decoding.
-    #[error(
-        "The decoded value {0} does not fit into the usize type of this \
-         architecture"
+    #[cfg_attr(
+        feature = "std",
+        error("The decoded value {0} does not fit into the usize type of this architecture")
     )]
     OutsideUsizeRange(u64),
     /// An array in the pickle has too many elements.
-    #[error("An array has too many elements: {0}")]
+    #[cfg_attr(feature = "std", error("An array has too many elements: {0}"))]
     ArrayTooBig(usize),
     /// TODO
-    #[error("TODO {0}")]
+    #[cfg_attr(feature = "std", error("TODO {0}"))]
     UnknownEnumVariant(u8),
 }
 
 /// Error type describing failure modes for libolm pickle decoding.
-#[derive(Debug, Error)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+#[derive(Debug)]
 pub enum EncodeError {
-    /// There was an error while writing to the buffer.
-    #[error(transparent)]
-    IO(#[from] std::io::Error),
     /// The usize value that should be encoded doesn't fit into the u32 range of
     /// values.
-    #[error("The usize value {0} does not fit into the u32 range of values.")]
+    #[cfg_attr(
+        feature = "std",
+        error("The usize value {0} does not fit into the u32 range of values.")
+    )]
     OutsideU32Range(usize),
     /// An array in the pickle has too many elements.
-    #[error("An array has too many elements: {0}")]
+    #[cfg_attr(feature = "std", error("An array has too many elements: {0}"))]
     ArrayTooBig(usize),
 }

--- a/crates/matrix-pickle/src/lib.rs
+++ b/crates/matrix-pickle/src/lib.rs
@@ -26,6 +26,9 @@
     unused_qualifications
 )]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
+
+extern crate alloc;
 
 extern crate self as matrix_pickle;
 
@@ -44,9 +47,9 @@ pub use error::*;
 
 #[cfg(test)]
 mod test {
-    use proptest::prelude::*;
-
     use super::*;
+    use alloc::{boxed::Box, vec, vec::Vec};
+    use proptest::prelude::*;
 
     macro_rules! encode_cycle {
         ($value:expr => $type:ty) => {


### PR DESCRIPTION
Using `bytes::buf::{Buf, BufMut}` instead of `std::io::{Cursor, Read, Write}` makes the create more flexible without changing the `Decode`/`Encode` traits considerably and now has the benefit of adding no_std(with alloc) support.