### PR TITLE
Return the correct number of bytes written for u8-arrays

### DIFF
--- a/crates/matrix-pickle/src/encode.rs
+++ b/crates/matrix-pickle/src/encode.rs
@@ -18,7 +18,7 @@ use crate::{EncodeError, MAX_ARRAY_LENGTH};
 
 /// A trait for encoding values into the `matrix-pickle` binary format.
 pub trait Encode {
-    /// Try to encode and write a value to the given writer.
+    /// Try to encode and write a value to the given writer, returning how many bytes were written.
     fn encode(&self, writer: &mut impl Write) -> Result<usize, EncodeError>;
 
     /// Try to encode a value into a new `Vec`.
@@ -48,7 +48,7 @@ impl<const N: usize> Encode for [u8; N] {
     fn encode(&self, writer: &mut impl Write) -> Result<usize, EncodeError> {
         writer.write_all(self)?;
 
-        Ok(self.len() * 8)
+        Ok(N)
     }
 }
 

--- a/crates/matrix-pickle/src/lib.rs
+++ b/crates/matrix-pickle/src/lib.rs
@@ -65,6 +65,16 @@ mod test {
         };
     }
 
+    macro_rules! encode_length_check {
+        ($value:expr) => {
+            let mut buffer = Vec::new();
+            let size = $value
+                .encode(&mut buffer)
+                .expect("We can always encode into to a Vec");
+            assert_eq!(size, buffer.len());
+        };
+    }
+
     #[test]
     fn encode_cycle() {
         encode_cycle!(10u8 => u8);
@@ -73,6 +83,16 @@ mod test {
         encode_cycle!(true => bool);
         encode_cycle!(false => bool);
         encode_cycle!(vec![1, 2, 3, 4] => Vec<u8>);
+    }
+
+    #[test]
+    fn encode_length_check() {
+        encode_length_check!(10u8);
+        encode_length_check!(10u32);
+        encode_length_check!(10usize);
+        encode_length_check!(true);
+        encode_length_check!(false);
+        encode_length_check!([1u32, 2u32, 3u32, 4u32]);
     }
 
     proptest! {


### PR DESCRIPTION
I believe using `self.len() * 8` is wrong here because `self` is already an array of bytes.