### PR TITLE
Fix the license in the toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "matrix-pickle"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "matrix-pickle-derive",
@@ -138,10 +138,10 @@ dependencies = [
 
 [[package]]
 name = "matrix-pickle-derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro-crate",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -188,26 +188,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
@@ -396,12 +394,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/matrix-pickle-derive/Cargo.toml
+++ b/crates/matrix-pickle-derive/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 edition = "2021"
 description = "Derive support for matrix-pickle"
 repository = "https://github.com/matrix-org/matrix-pickle"
-license = "MIT"
+license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [lib]

--- a/crates/matrix-pickle/Cargo.toml
+++ b/crates/matrix-pickle/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.1"
 edition = "2021"
 description = "A simple binary encoding format used in the Matrix world"
 repository = "https://github.com/matrix-org/matrix-pickle"
-license = "MIT"
+license = "Apache-2.0"
 rust-version = { workspace = true }
 
 [features]


### PR DESCRIPTION
This project used to be MIT licensed while it was a weekend project, it got relicensed as Apache-2.0 after it got under the banner of the Matrix foundation.

This closes #16.